### PR TITLE
fix: correct language-server binary name and grammar branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ require("surrealql").setup({
   treesitter = {
     enable = true,
     url = "https://github.com/surrealdb/surrealql-tree-sitter",
-    branch = "main",
+    branch = "master",
     files = { "src/parser.c", "src/scanner.c" },
   },
   filetype = {
@@ -71,7 +71,7 @@ require("surrealql").setup({
   lsp = {
     enable = false,
     auto_install = true,
-    cmd = { "surreal-language-server" },
+    cmd = { "surrealql-language-server" },
     on_attach = nil,
     capabilities = nil,
   },
@@ -144,7 +144,7 @@ require("surrealql").setup({
   lsp = {
     enable = true,
     auto_install = false,
-    cmd = { "surreal-language-server" },
+    cmd = { "surrealql-language-server" },
     on_attach = function(client, bufnr)
       -- your keymaps here
     end,

--- a/lua/surrealql/config.lua
+++ b/lua/surrealql/config.lua
@@ -4,7 +4,7 @@ M.defaults = {
   treesitter = {
     enable = true,
     url = "https://github.com/surrealdb/surrealql-tree-sitter",
-    branch = "main",
+    branch = "master",
     files = { "src/parser.c", "src/scanner.c" },
   },
   filetype = {
@@ -16,7 +16,7 @@ M.defaults = {
   lsp = {
     enable = false,
     auto_install = true,
-    cmd = { "surreal-language-server" },
+    cmd = { "surrealql-language-server" },
     on_attach = nil,
     capabilities = nil,
   },

--- a/lua/surrealql/install.lua
+++ b/lua/surrealql/install.lua
@@ -38,8 +38,8 @@ function M.is_installed()
   if vim.fn.executable(managed) == 1 then
     return true, managed
   end
-  if vim.fn.executable("surreal-language-server") == 1 then
-    return true, "surreal-language-server"
+  if vim.fn.executable("surrealql-language-server") == 1 then
+    return true, "surrealql-language-server"
   end
   return false, nil
 end
@@ -89,7 +89,7 @@ local function cargo_install(on_done)
     end
     vim.schedule(function()
       vim.notify("[surrealql] Language server installed via cargo.", vim.log.levels.INFO)
-      on_done(true, "surreal-language-server")
+      on_done(true, "surrealql-language-server")
     end)
   end)
 end

--- a/lua/surrealql/lsp.lua
+++ b/lua/surrealql/lsp.lua
@@ -50,7 +50,7 @@ function M.setup(lsp_config)
   end
 
   vim.notify(
-    "[surrealql] surreal-language-server not found. Run :SurrealQLInstall or set lsp.auto_install = true.",
+    "[surrealql] surrealql-language-server not found. Run :SurrealQLInstall or set lsp.auto_install = true.",
     vim.log.levels.WARN
   )
 end

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -9,7 +9,7 @@ describe("surrealql.config", function()
   it("exposes treesitter defaults", function()
     assert.is_true(config.defaults.treesitter.enable)
     assert.equals("https://github.com/surrealdb/surrealql-tree-sitter", config.defaults.treesitter.url)
-    assert.equals("main", config.defaults.treesitter.branch)
+    assert.equals("master", config.defaults.treesitter.branch)
     assert.same({ "src/parser.c", "src/scanner.c" }, config.defaults.treesitter.files)
   end)
 

--- a/tests/install_spec.lua
+++ b/tests/install_spec.lua
@@ -43,13 +43,13 @@ describe("surrealql.install", function()
       local orig = vim.fn.executable
       vim.fn.executable = function(p)
         if p == managed then return 0 end
-        if p == "surreal-language-server" then return 1 end
+        if p == "surrealql-language-server" then return 1 end
         return 0
       end
       local ok, bin = install.is_installed()
       vim.fn.executable = orig
       assert.is_true(ok)
-      assert.equals("surreal-language-server", bin)
+      assert.equals("surrealql-language-server", bin)
     end)
   end)
 

--- a/tests/lsp_spec.lua
+++ b/tests/lsp_spec.lua
@@ -16,21 +16,21 @@ describe("surrealql.lsp", function()
   describe("setup", function()
     local function mock_install(installed)
       package.loaded["surrealql.install"] = {
-        is_installed = function() return installed, installed and "surreal-language-server" or nil end,
+        is_installed = function() return installed, installed and "surrealql-language-server" or nil end,
         install = function(cb) cb(false) end,
       }
     end
 
     it("does nothing when enable is false", function()
       mock_install(true)
-      lsp.setup({ enable = false, cmd = { "surreal-language-server" } })
+      lsp.setup({ enable = false, cmd = { "surrealql-language-server" } })
       local ok, _ = pcall(vim.api.nvim_get_autocmds, { group = "surrealql_lsp" })
       assert.is_false(ok)
     end)
 
     it("creates a FileType autocmd when binary is installed", function()
       mock_install(true)
-      lsp.setup({ enable = true, cmd = { "surreal-language-server" } })
+      lsp.setup({ enable = true, cmd = { "surrealql-language-server" } })
       local autocmds = vim.api.nvim_get_autocmds({ group = "surrealql_lsp", event = "FileType" })
       assert.equals(1, #autocmds)
       assert.equals("surrealql", autocmds[1].pattern)
@@ -38,8 +38,8 @@ describe("surrealql.lsp", function()
 
     it("replaces a previous autocmd group on repeated setup calls", function()
       mock_install(true)
-      lsp.setup({ enable = true, cmd = { "surreal-language-server" } })
-      lsp.setup({ enable = true, cmd = { "surreal-language-server" } })
+      lsp.setup({ enable = true, cmd = { "surrealql-language-server" } })
+      lsp.setup({ enable = true, cmd = { "surrealql-language-server" } })
       local autocmds = vim.api.nvim_get_autocmds({ group = "surrealql_lsp", event = "FileType" })
       assert.equals(1, #autocmds)
     end)
@@ -51,7 +51,7 @@ describe("surrealql.lsp", function()
         install = function(cb) installed_cb = cb end,
       }
 
-      lsp.setup({ enable = true, auto_install = true, cmd = { "surreal-language-server" } })
+      lsp.setup({ enable = true, auto_install = true, cmd = { "surrealql-language-server" } })
       assert.is_nil(vim.api.nvim_get_autocmds and (function()
         local ok, cmds = pcall(vim.api.nvim_get_autocmds, { group = "surrealql_lsp" })
         return ok and cmds[1] or nil
@@ -71,7 +71,7 @@ describe("surrealql.lsp", function()
       vim.notify = function(_, level)
         if level == vim.log.levels.WARN then warned = true end
       end
-      lsp.setup({ enable = true, auto_install = false, cmd = { "surreal-language-server" } })
+      lsp.setup({ enable = true, auto_install = false, cmd = { "surrealql-language-server" } })
       vim.notify = orig
       assert.is_true(warned)
     end)
@@ -83,12 +83,12 @@ describe("surrealql.lsp", function()
       local orig = vim.lsp.start
       vim.lsp.start = function(cfg) captured = cfg end
 
-      lsp.start({ cmd = { "surreal-language-server" } })
+      lsp.start({ cmd = { "surrealql-language-server" } })
 
       vim.lsp.start = orig
       assert.is_not_nil(captured)
       assert.equals("surrealql", captured.name)
-      assert.same({ "surreal-language-server" }, captured.cmd)
+      assert.same({ "surrealql-language-server" }, captured.cmd)
     end)
 
     it("passes on_attach and capabilities through", function()
@@ -98,7 +98,7 @@ describe("surrealql.lsp", function()
 
       local on_attach = function() end
       local caps = { textDocument = {} }
-      lsp.start({ cmd = { "surreal-language-server" }, on_attach = on_attach, capabilities = caps })
+      lsp.start({ cmd = { "surrealql-language-server" }, on_attach = on_attach, capabilities = caps })
 
       vim.lsp.start = orig
       assert.equals(on_attach, captured.on_attach)
@@ -110,7 +110,7 @@ describe("surrealql.lsp", function()
       local orig = vim.lsp.start
       vim.lsp.start = function(cfg) captured = cfg end
 
-      lsp.start({ cmd = { "surreal-language-server" } })
+      lsp.start({ cmd = { "surrealql-language-server" } })
 
       vim.lsp.start = orig
       assert.truthy(vim.tbl_contains(captured.filetypes, "surrealql"))
@@ -122,8 +122,8 @@ describe("surrealql.lsp", function()
       assert.is_false(defaults.enable)
     end)
 
-    it("default cmd is surreal-language-server", function()
-      assert.same({ "surreal-language-server" }, defaults.cmd)
+    it("default cmd is surrealql-language-server", function()
+      assert.same({ "surrealql-language-server" }, defaults.cmd)
     end)
   end)
 end)


### PR DESCRIPTION
The plugin referenced `surreal-language-server` (missing the `ql`) in three places, while the published release binary and the `cargo install` crate are both named `surrealql-language-server`:

- `config.lua` — default `lsp.cmd`
- `install.lua` — the `$PATH` fallback in `is_installed()`
- `install.lua` — the value `cargo_install` reports

The wrong name meant a binary already on `$PATH` (or installed via cargo) was never detected, and the default `lsp.cmd` launched a non-existent executable. The managed-download happy path worked only because `bin_path()` hard-codes the correct name.

Separately, the tree-sitter grammar's default branch is `master`, not `main`, so the parser `install_info.branch` pointed `:TSInstall surrealql` at a branch that does not exist.

README config examples updated to match. Tests updated accordingly; `make test` is green.
