### PR TITLE
feat: highlight SurrealQL in surql`...` template literals (JS/TS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Neovim plugin for [SurrealQL](https://surrealdb.com/docs/surrealql), powered by 
 - Filetype detection for `.surql` and `.surrealql` files
 - Syntax highlighting via tree-sitter
 - Embedded JavaScript highlighting inside `FUNCTION() { ... }` scripting bodies
+- Embedded SurrealQL highlighting inside `surql`...`` tagged templates in JavaScript/TypeScript
 - Smart indentation for blocks, objects, arrays, and control flow
 - Code folding for blocks, objects, arrays, and statements
 - Scope tracking for `LET` variables, closure params, and function definitions
@@ -156,6 +157,26 @@ require("surrealql").setup({
 Prebuilt binaries are available for Linux (x86_64, arm64), macOS (Apple Silicon), and Windows (x86_64). macOS Intel falls back to `cargo install surrealql-language-server` automatically if Rust is available.
 
 The server provides diagnostics, hover, completions, go-to-definition, references, rename, code actions, signature help, and call hierarchy.
+
+## SurrealQL in JavaScript/TypeScript
+
+The surrealdb JavaScript/TypeScript SDK lets you write queries as tagged
+template literals. This plugin highlights their contents as SurrealQL:
+
+```ts
+const result = await db.query(surql`
+  SELECT name, age FROM user WHERE age > 18
+`);
+```
+
+Both `surql` and `surrealql` tags are recognized, whether called directly
+(`surql`...``) or as a member (`db.surql`...``), in `.ts`, `.tsx`, `.js`, and
+`.jsx` files.
+
+This requires the host `typescript` / `tsx` / `javascript` parsers to be
+installed (`:TSInstall typescript tsx javascript`). The injection queries use
+the `; extends` modeline, so they add to — rather than replace — any
+injections you already have.
 
 ## Grammar
 

--- a/after/queries/javascript/injections.scm
+++ b/after/queries/javascript/injections.scm
@@ -1,0 +1,20 @@
+; extends
+
+; Highlight SurrealQL inside surql`...` / surrealql`...` tagged template
+; literals (e.g. the surrealdb JavaScript/TypeScript SDK). #offset! trims the
+; surrounding backticks from the injected region.
+((call_expression
+   function: (identifier) @_tag
+   arguments: (template_string) @injection.content)
+ (#any-of? @_tag "surql" "surrealql")
+ (#set! injection.language "surrealql")
+ (#offset! @injection.content 0 1 0 -1))
+
+; member-expression tag, e.g. db.surql`...`
+((call_expression
+   function: (member_expression
+     property: (property_identifier) @_tag)
+   arguments: (template_string) @injection.content)
+ (#any-of? @_tag "surql" "surrealql")
+ (#set! injection.language "surrealql")
+ (#offset! @injection.content 0 1 0 -1))

--- a/after/queries/tsx/injections.scm
+++ b/after/queries/tsx/injections.scm
@@ -1,0 +1,20 @@
+; extends
+
+; Highlight SurrealQL inside surql`...` / surrealql`...` tagged template
+; literals (e.g. the surrealdb JavaScript/TypeScript SDK). #offset! trims the
+; surrounding backticks from the injected region.
+((call_expression
+   function: (identifier) @_tag
+   arguments: (template_string) @injection.content)
+ (#any-of? @_tag "surql" "surrealql")
+ (#set! injection.language "surrealql")
+ (#offset! @injection.content 0 1 0 -1))
+
+; member-expression tag, e.g. db.surql`...`
+((call_expression
+   function: (member_expression
+     property: (property_identifier) @_tag)
+   arguments: (template_string) @injection.content)
+ (#any-of? @_tag "surql" "surrealql")
+ (#set! injection.language "surrealql")
+ (#offset! @injection.content 0 1 0 -1))

--- a/after/queries/typescript/injections.scm
+++ b/after/queries/typescript/injections.scm
@@ -1,0 +1,20 @@
+; extends
+
+; Highlight SurrealQL inside surql`...` / surrealql`...` tagged template
+; literals (e.g. the surrealdb JavaScript/TypeScript SDK). #offset! trims the
+; surrounding backticks from the injected region.
+((call_expression
+   function: (identifier) @_tag
+   arguments: (template_string) @injection.content)
+ (#any-of? @_tag "surql" "surrealql")
+ (#set! injection.language "surrealql")
+ (#offset! @injection.content 0 1 0 -1))
+
+; member-expression tag, e.g. db.surql`...`
+((call_expression
+   function: (member_expression
+     property: (property_identifier) @_tag)
+   arguments: (template_string) @injection.content)
+ (#any-of? @_tag "surql" "surrealql")
+ (#set! injection.language "surrealql")
+ (#offset! @injection.content 0 1 0 -1))

--- a/tests/injection_spec.lua
+++ b/tests/injection_spec.lua
@@ -1,0 +1,19 @@
+describe("surrealql js/ts injections", function()
+  for _, lang in ipairs({ "typescript", "tsx", "javascript" }) do
+    it("ships a valid injection query for " .. lang, function()
+      local files = vim.api.nvim_get_runtime_file("after/queries/" .. lang .. "/injections.scm", false)
+      assert.is_true(#files > 0, "after/queries/" .. lang .. "/injections.scm should be on the runtimepath")
+
+      -- Validate the query parses, but only when the host grammar is present.
+      -- CI installs no language parsers, so the parse check is skipped there.
+      if not pcall(vim.treesitter.query.parse, lang, "") then
+        return
+      end
+
+      local src = table.concat(vim.fn.readfile(files[1]), "\n")
+      assert.has_no.errors(function()
+        vim.treesitter.query.parse(lang, src)
+      end)
+    end)
+  end
+end)


### PR DESCRIPTION
Adds injection queries for the `typescript`, `tsx`, and `javascript` grammars that highlight the contents of `surql`...`` / `surrealql`...`` tagged template literals (as produced by the surrealdb JavaScript/TypeScript SDK) as SurrealQL.

This is the inverse of the existing JS-in-surql injection: that highlights JavaScript inside a `.surql` `FUNCTION(){}` body; this highlights SurrealQL inside a `surql`...`` literal in a `.ts`/`.js` file.

- Both `surql` and `surrealql` tags, as plain (`surql`...``) and member (`db.surql`...``) calls
- `.ts`, `.tsx`, `.js`, `.jsx`
- Uses the `; extends` modeline, so it augments rather than replaces any injections you already have
- Requires the host `typescript`/`tsx`/`javascript` parsers, plus the `surrealql` parser this plugin installs

Adds `tests/injection_spec.lua`, which validates the queries parse against the host grammars when those parsers are installed (skipped in CI, which installs no language parsers). `make test` passes.

### Preview
<img width="497" height="183" alt="image" src="https://github.com/user-attachments/assets/8029aaf4-9b3d-4e5a-89a5-c66a951858b7" />

