### PR TITLE
fix: do not error on nvim-treesitter main branch

### DIFF
--- a/lua/surrealql/init.lua
+++ b/lua/surrealql/init.lua
@@ -29,6 +29,13 @@ function M._register_parser(ts_config)
     return
   end
 
+  -- nvim-treesitter `main` removed get_parser_configs() in favour of a
+  -- different parser registry. Bail out cleanly instead of calling a nil
+  -- value, which previously errored at plugin load on the `main` branch.
+  if type(parsers.get_parser_configs) ~= "function" then
+    return
+  end
+
   local parser_configs = parsers.get_parser_configs()
   if parser_configs.surrealql then
     return

--- a/tests/surrealql_spec.lua
+++ b/tests/surrealql_spec.lua
@@ -47,6 +47,14 @@ describe("surrealql", function()
       end)
     end)
 
+    it("does not error on nvim-treesitter main (no get_parser_configs)", function()
+      -- The `main` branch exposes the module but not get_parser_configs().
+      package.loaded["nvim-treesitter.parsers"] = {}
+      assert.has_no.errors(function()
+        surrealql._register_parser(defaults.treesitter)
+      end)
+    end)
+
     it("registers the parser when treesitter is present", function()
       local parser_configs = {}
       package.loaded["nvim-treesitter.parsers"] = {


### PR DESCRIPTION
`_register_parser` calls `parsers.get_parser_configs()` unconditionally. nvim-treesitter's `main` branch removed that registry API — the module still loads (so the existing `pcall(require, ...)` passes), but the call hits a `nil` value and throws. Because `plugin/surrealql.lua` calls `_register_parser` at load time, the plugin errors on startup for anyone running nvim-treesitter `main`.

This guards on `get_parser_configs` being a function and returns cleanly otherwise. Verified against real nvim-treesitter `main` (where `get_parser_configs` is `nil`). Adds a regression test; `make test` passes.

Note: this is the minimal "stop crashing" fix. Full parser support on nvim-treesitter `main` (which uses a different install mechanism) is a larger change worth discussing separately.
