### PR TITLE
Fix LSP binary name, install robustness, grammar branch & parser registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Neovim plugin for [SurrealQL](https://surrealdb.com/docs/surrealql), powered by 
 - [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
 - A C compiler (gcc or clang) for building the parser
 
-> **Treesitter parser / Neovim ABI:** the grammar on `master` is generated
-> at tree-sitter **ABI 15**, which only **Neovim 0.12+** can load — on 0.11
-> the parser is rejected (`Parser could not be created`). ABI-14 support
-> for 0.11 is tracked in the [grammar repo](https://github.com/surrealdb/surrealql-tree-sitter).
-> This affects only the Treesitter path; the **LSP's semantic-token
-> highlighting is unaffected** (the server carries its own tree-sitter
-> runtime), so LSP highlighting works on 0.10/0.11 regardless.
+> **Treesitter parser / Neovim ABI:** [surrealql-tree-sitter#11](https://github.com/surrealdb/surrealql-tree-sitter/pull/11)
+> moves the grammar to tree-sitter **ABI 14**, which Neovim **0.10+** loads.
+> Until that lands the parser is ABI 15 and needs Neovim **0.12+** (0.11
+> rejects it with `Parser could not be created`). Either way this affects
+> only the Treesitter path — the **LSP's semantic-token highlighting is
+> independent** (the server carries its own tree-sitter runtime) and works
+> on 0.10+ regardless.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Neovim plugin for [SurrealQL](https://surrealdb.com/docs/surrealql), powered by 
 
 ## Requirements
 
-- Neovim >= 0.9.0
+- Neovim >= 0.9.0 (Treesitter highlighting, indentation, folding)
+- Neovim >= 0.10.0 for the bundled LSP auto-installer (it uses `vim.system`)
 - [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
 - A C compiler (gcc or clang) for building the parser
 
@@ -71,7 +72,7 @@ require("surrealql").setup({
   lsp = {
     enable = false,
     auto_install = true,
-    cmd = { "surreal-language-server" },
+    cmd = { "surrealql-language-server" },
     on_attach = nil,
     capabilities = nil,
   },
@@ -144,7 +145,7 @@ require("surrealql").setup({
   lsp = {
     enable = true,
     auto_install = false,
-    cmd = { "surreal-language-server" },
+    cmd = { "surrealql-language-server" },
     on_attach = function(client, bufnr)
       -- your keymaps here
     end,
@@ -153,9 +154,21 @@ require("surrealql").setup({
 })
 ```
 
-Prebuilt binaries are available for Linux (x86_64, arm64), macOS (Apple Silicon), and Windows (x86_64). macOS Intel falls back to `cargo install surrealql-language-server` automatically if Rust is available.
+Prebuilt binaries are available for Linux (x86_64, arm64), macOS (Apple Silicon), and Windows (x86_64). On platforms without a prebuilt binary (e.g. macOS Intel) the plugin builds from source: it fetches the tree-sitter grammar and runs `cargo install surrealql-language-server` with `TREE_SITTER_SURREALQL_DIR` pointed at it, so `cargo` (Rust) and `git` are required for that path.
 
-The server provides diagnostics, hover, completions, go-to-definition, references, rename, code actions, signature help, and call hierarchy.
+The server provides:
+
+- **Semantic-token highlighting** (parser-accurate; marks definitions and builtin functions)
+- Diagnostics, hover, completions
+- Go-to-definition, references, document highlight
+- Rename, code actions, signature help, call hierarchy
+- Inlay hints, document & workspace symbols
+
+The semantic tokens **refine** the Treesitter highlighting above rather than
+replacing it — both are active by default (Treesitter is instant and works
+offline; semantic tokens add parser-level accuracy such as definition vs.
+reference and builtin vs. user functions). To use only one, disable the
+other (`vim.lsp.semantic_tokens` / nvim-treesitter `highlight`).
 
 ## Grammar
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,17 @@ Neovim plugin for [SurrealQL](https://surrealdb.com/docs/surrealql), powered by 
 
 ## Requirements
 
-- Neovim >= 0.9.0 (Treesitter highlighting, indentation, folding)
 - Neovim >= 0.10.0 for the bundled LSP auto-installer (it uses `vim.system`)
 - [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
 - A C compiler (gcc or clang) for building the parser
+
+> **Treesitter parser / Neovim ABI:** the grammar on `master` is generated
+> at tree-sitter **ABI 15**, which only **Neovim 0.12+** can load — on 0.11
+> the parser is rejected (`Parser could not be created`). ABI-14 support
+> for 0.11 is tracked in the [grammar repo](https://github.com/surrealdb/surrealql-tree-sitter).
+> This affects only the Treesitter path; the **LSP's semantic-token
+> highlighting is unaffected** (the server carries its own tree-sitter
+> runtime), so LSP highlighting works on 0.10/0.11 regardless.
 
 ## Installation
 
@@ -60,7 +67,7 @@ require("surrealql").setup({
   treesitter = {
     enable = true,
     url = "https://github.com/surrealdb/surrealql-tree-sitter",
-    branch = "main",
+    branch = "master",
     files = { "src/parser.c", "src/scanner.c" },
   },
   filetype = {

--- a/doc/surrealql.txt
+++ b/doc/surrealql.txt
@@ -21,11 +21,15 @@ tree-sitter grammar from https://github.com/surrealdb/surrealql-tree-sitter.
 ==============================================================================
 2. REQUIREMENTS                                     *surrealql-requirements*
 
-  - Neovim >= 0.9.0 (Treesitter highlighting, indentation, folding)
   - Neovim >= 0.10.0 for the bundled LSP auto-installer (uses |vim.system|)
   - nvim-treesitter (https://github.com/nvim-treesitter/nvim-treesitter)
     for syntax highlighting, indentation, and folding
   - A C compiler (gcc/clang) for building the parser
+
+Note: the grammar on `master` is generated at tree-sitter ABI 15, which only
+Neovim 0.12+ can load; on 0.11 the parser is rejected. This affects only the
+Treesitter path — the LSP's semantic-token highlighting works on 0.10/0.11
+regardless, since the server bundles its own tree-sitter runtime.
 
 ==============================================================================
 3. INSTALLATION                                     *surrealql-installation*
@@ -54,7 +58,7 @@ Default configuration: >lua
     treesitter = {
       enable = true,
       url = "https://github.com/surrealdb/surrealql-tree-sitter",
-      branch = "main",
+      branch = "master",
       files = { "src/parser.c", "src/scanner.c" },
     },
     filetype = {

--- a/doc/surrealql.txt
+++ b/doc/surrealql.txt
@@ -26,10 +26,11 @@ tree-sitter grammar from https://github.com/surrealdb/surrealql-tree-sitter.
     for syntax highlighting, indentation, and folding
   - A C compiler (gcc/clang) for building the parser
 
-Note: the grammar on `master` is generated at tree-sitter ABI 15, which only
-Neovim 0.12+ can load; on 0.11 the parser is rejected. This affects only the
-Treesitter path — the LSP's semantic-token highlighting works on 0.10/0.11
-regardless, since the server bundles its own tree-sitter runtime.
+Note: surrealql-tree-sitter#11 moves the grammar to tree-sitter ABI 14, which
+Neovim 0.10+ loads. Until that lands the parser is ABI 15 and needs Neovim
+0.12+ (0.11 rejects it). This affects only the Treesitter path — the LSP's
+semantic-token highlighting works on 0.10+ regardless, since the server
+bundles its own tree-sitter runtime.
 
 ==============================================================================
 3. INSTALLATION                                     *surrealql-installation*

--- a/doc/surrealql.txt
+++ b/doc/surrealql.txt
@@ -21,7 +21,8 @@ tree-sitter grammar from https://github.com/surrealdb/surrealql-tree-sitter.
 ==============================================================================
 2. REQUIREMENTS                                     *surrealql-requirements*
 
-  - Neovim >= 0.9.0
+  - Neovim >= 0.9.0 (Treesitter highlighting, indentation, folding)
+  - Neovim >= 0.10.0 for the bundled LSP auto-installer (uses |vim.system|)
   - nvim-treesitter (https://github.com/nvim-treesitter/nvim-treesitter)
     for syntax highlighting, indentation, and folding
   - A C compiler (gcc/clang) for building the parser
@@ -61,6 +62,13 @@ Default configuration: >lua
       tabstop = 2,
       shiftwidth = 2,
       expandtab = true,
+    },
+    lsp = {
+      enable = false,
+      auto_install = true,
+      cmd = { "surrealql-language-server" },
+      on_attach = nil,
+      capabilities = nil,
     },
   })
 <
@@ -103,18 +111,28 @@ LSP is disabled by default (`enable = false`). When enabled, the server
 attaches automatically whenever a SurrealQL buffer is opened.
 
 Prebuilt binaries are available for Linux x86_64/arm64, macOS Apple Silicon,
-and Windows x86_64. macOS Intel falls back to `cargo install` if Rust is
-available.
+and Windows x86_64. On platforms without a prebuilt binary (e.g. macOS Intel)
+the plugin builds from source via `cargo install`, fetching the tree-sitter
+grammar and pointing the build at it; this path needs `cargo` (Rust) and
+`git`.
 
 Capabilities provided by the server:
+  • Semantic-token highlighting (definitions, builtin functions)
   • Diagnostics
   • Hover
   • Completions
-  • Go-to definition and references
+  • Go-to definition, references, document highlight
   • Rename
   • Code actions
   • Signature help
   • Call hierarchy
+  • Inlay hints
+  • Document and workspace symbols
+
+The server's semantic tokens refine the Treesitter highlighting rather than
+replacing it; both are active by default. Treesitter is instant and works
+offline, while semantic tokens add parser-level accuracy (definition vs.
+reference, builtin vs. user functions).
 
 ==============================================================================
 7. COMMANDS                                           *surrealql-commands*

--- a/lua/surrealql/config.lua
+++ b/lua/surrealql/config.lua
@@ -4,7 +4,7 @@ M.defaults = {
   treesitter = {
     enable = true,
     url = "https://github.com/surrealdb/surrealql-tree-sitter",
-    branch = "main",
+    branch = "master",
     files = { "src/parser.c", "src/scanner.c" },
   },
   filetype = {

--- a/lua/surrealql/config.lua
+++ b/lua/surrealql/config.lua
@@ -16,7 +16,7 @@ M.defaults = {
   lsp = {
     enable = false,
     auto_install = true,
-    cmd = { "surreal-language-server" },
+    cmd = { "surrealql-language-server" },
     on_attach = nil,
     capabilities = nil,
   },

--- a/lua/surrealql/init.lua
+++ b/lua/surrealql/init.lua
@@ -30,21 +30,22 @@ function M._register_parser(ts_config)
   end
 
   local parser_configs = parsers.get_parser_configs()
-  if parser_configs.surrealql then
-    return
-  end
 
-  parser_configs.surrealql = {
-    install_info = {
-      url = ts_config.url,
-      files = ts_config.files,
-      branch = ts_config.branch,
-      generate_requires_npm = false,
-      requires_generate_from_grammar = false,
-    },
-    filetype = "surrealql",
-    maintainers = { "@surrealdb" },
+  -- Update `install_info` on an existing entry rather than bailing out.
+  -- The plugin eager-registers at load with defaults (before `setup()`),
+  -- so a guard that returned early here made `setup({ treesitter = ... })`
+  -- a silent no-op. Every caller passes the live config, so last-writer
+  -- (the post-`setup()` merged config) correctly wins.
+  local entry = parser_configs.surrealql
+    or { filetype = "surrealql", maintainers = { "@surrealdb" } }
+  entry.install_info = {
+    url = ts_config.url,
+    files = ts_config.files,
+    branch = ts_config.branch,
+    generate_requires_npm = false,
+    requires_generate_from_grammar = false,
   }
+  parser_configs.surrealql = entry
 end
 
 return M

--- a/lua/surrealql/install.lua
+++ b/lua/surrealql/install.lua
@@ -1,6 +1,9 @@
 local M = {}
 
+local uv = vim.uv or vim.loop
+
 local REPO = "surrealdb/surrealql-language-server"
+local GRAMMAR_REPO = "https://github.com/surrealdb/surrealql-tree-sitter"
 
 local PLATFORM_BINARIES = {
   ["linux-x86_64"]  = "surrealql-language-server-linux-amd64",
@@ -10,7 +13,7 @@ local PLATFORM_BINARIES = {
 }
 
 local function platform_key()
-  local uname = vim.uv.os_uname()
+  local uname = uv.os_uname()
   local sys = uname.sysname:lower()
   local arch = uname.machine:lower()
 
@@ -27,7 +30,7 @@ end
 
 function M.bin_path()
   local name = "surrealql-language-server"
-  if vim.uv.os_uname().sysname:lower():find("windows") then
+  if uv.os_uname().sysname:lower():find("windows") then
     name = name .. ".exe"
   end
   return vim.fn.stdpath("data") .. "/surrealql/bin/" .. name
@@ -38,10 +41,24 @@ function M.is_installed()
   if vim.fn.executable(managed) == 1 then
     return true, managed
   end
-  if vim.fn.executable("surreal-language-server") == 1 then
-    return true, "surreal-language-server"
+  if vim.fn.executable("surrealql-language-server") == 1 then
+    return true, "surrealql-language-server"
   end
   return false, nil
+end
+
+-- Auto-install relies on `vim.system`, which is Neovim 0.10+. Fail loudly on
+-- older versions rather than throwing a nil-call error mid-install.
+local function ensure_system()
+  if vim.system then
+    return true
+  end
+  vim.notify(
+    "[surrealql] Automatic install requires Neovim 0.10+. Install surrealql-language-server "
+      .. "manually and point lsp.cmd at it (auto_install = false).",
+    vim.log.levels.ERROR
+  )
+  return false
 end
 
 local function download(filename, on_done)
@@ -59,10 +76,42 @@ local function download(filename, on_done)
       end)
       return
     end
-    vim.uv.fs_chmod(dest, 493) -- 0755
+    uv.fs_chmod(dest, 493) -- 0755
     vim.schedule(function()
       vim.notify("[surrealql] Language server installed.", vim.log.levels.INFO)
       on_done(true, dest)
+    end)
+  end)
+end
+
+-- The published crate builds against the sibling tree-sitter grammar repo
+-- (build.rs resolves `../surrealql-tree-sitter` or `TREE_SITTER_SURREALQL_DIR`)
+-- and is not bundled with it, so a bare `cargo install` fails. Fetch the
+-- grammar into the plugin's data dir and hand its path to the build.
+local function ensure_grammar(on_done)
+  local dir = vim.fn.stdpath("data") .. "/surrealql/surrealql-tree-sitter"
+  if vim.fn.isdirectory(dir) == 1 then
+    on_done(true, dir)
+    return
+  end
+  if vim.fn.executable("git") == 0 then
+    vim.notify(
+      "[surrealql] git not found; cannot fetch the tree-sitter grammar needed to build from source.",
+      vim.log.levels.ERROR
+    )
+    on_done(false)
+    return
+  end
+  vim.fn.mkdir(vim.fn.fnamemodify(dir, ":h"), "p")
+  vim.notify("[surrealql] Fetching tree-sitter grammar for build...", vim.log.levels.INFO)
+  vim.system({ "git", "clone", "--depth", "1", GRAMMAR_REPO, dir }, {}, function(result)
+    vim.schedule(function()
+      if result.code ~= 0 then
+        vim.notify("[surrealql] Grammar clone failed: " .. (result.stderr or ""), vim.log.levels.ERROR)
+        on_done(false)
+        return
+      end
+      on_done(true, dir)
     end)
   end)
 end
@@ -77,30 +126,45 @@ local function cargo_install(on_done)
     return
   end
 
-  vim.notify("[surrealql] Building language server via cargo (this may take a while)...", vim.log.levels.INFO)
-
-  vim.system({ "cargo", "install", "surrealql-language-server" }, {}, function(result)
-    if result.code ~= 0 then
-      vim.schedule(function()
-        vim.notify("[surrealql] cargo install failed: " .. (result.stderr or ""), vim.log.levels.ERROR)
-        on_done(false)
-      end)
+  ensure_grammar(function(ok, grammar_dir)
+    if not ok then
+      on_done(false)
       return
     end
-    vim.schedule(function()
-      vim.notify("[surrealql] Language server installed via cargo.", vim.log.levels.INFO)
-      on_done(true, "surreal-language-server")
-    end)
+    vim.notify("[surrealql] Building language server via cargo (this may take a while)...", vim.log.levels.INFO)
+    vim.system(
+      { "cargo", "install", "surrealql-language-server" },
+      { env = { TREE_SITTER_SURREALQL_DIR = grammar_dir } },
+      function(result)
+        if result.code ~= 0 then
+          vim.schedule(function()
+            vim.notify("[surrealql] cargo install failed: " .. (result.stderr or ""), vim.log.levels.ERROR)
+            on_done(false)
+          end)
+          return
+        end
+        vim.schedule(function()
+          vim.notify("[surrealql] Language server installed via cargo.", vim.log.levels.INFO)
+          -- Installed onto ~/.cargo/bin, which is expected to be on PATH.
+          on_done(true, "surrealql-language-server")
+        end)
+      end
+    )
   end)
 end
 
 function M.install(on_done)
   on_done = on_done or function() end
 
-  local ok, _ = M.is_installed()
+  local ok = M.is_installed()
   if ok then
     vim.notify("[surrealql] Language server is already installed.", vim.log.levels.INFO)
     on_done(true)
+    return
+  end
+
+  if not ensure_system() then
+    on_done(false)
     return
   end
 

--- a/lua/surrealql/lsp.lua
+++ b/lua/surrealql/lsp.lua
@@ -1,9 +1,8 @@
 local M = {}
 
 function M.start(lsp_config)
-  local root = vim.fs.dirname(
-    vim.fs.find({ ".git", "surreal.json" }, { upward = true })[1]
-  ) or vim.fn.getcwd()
+  local marker = vim.fs.find({ ".git", "surreal.json" }, { upward = true })[1]
+  local root = (marker and vim.fs.dirname(marker)) or vim.fn.getcwd()
 
   vim.lsp.start({
     name = "surrealql",
@@ -50,7 +49,7 @@ function M.setup(lsp_config)
   end
 
   vim.notify(
-    "[surrealql] surreal-language-server not found. Run :SurrealQLInstall or set lsp.auto_install = true.",
+    "[surrealql] surrealql-language-server not found. Run :SurrealQLInstall or set lsp.auto_install = true.",
     vim.log.levels.WARN
   )
 end

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -9,7 +9,7 @@ describe("surrealql.config", function()
   it("exposes treesitter defaults", function()
     assert.is_true(config.defaults.treesitter.enable)
     assert.equals("https://github.com/surrealdb/surrealql-tree-sitter", config.defaults.treesitter.url)
-    assert.equals("main", config.defaults.treesitter.branch)
+    assert.equals("master", config.defaults.treesitter.branch)
     assert.same({ "src/parser.c", "src/scanner.c" }, config.defaults.treesitter.files)
   end)
 

--- a/tests/install_spec.lua
+++ b/tests/install_spec.lua
@@ -43,13 +43,13 @@ describe("surrealql.install", function()
       local orig = vim.fn.executable
       vim.fn.executable = function(p)
         if p == managed then return 0 end
-        if p == "surreal-language-server" then return 1 end
+        if p == "surrealql-language-server" then return 1 end
         return 0
       end
       local ok, bin = install.is_installed()
       vim.fn.executable = orig
       assert.is_true(ok)
-      assert.equals("surreal-language-server", bin)
+      assert.equals("surrealql-language-server", bin)
     end)
   end)
 

--- a/tests/lsp_spec.lua
+++ b/tests/lsp_spec.lua
@@ -16,21 +16,21 @@ describe("surrealql.lsp", function()
   describe("setup", function()
     local function mock_install(installed)
       package.loaded["surrealql.install"] = {
-        is_installed = function() return installed, installed and "surreal-language-server" or nil end,
+        is_installed = function() return installed, installed and "surrealql-language-server" or nil end,
         install = function(cb) cb(false) end,
       }
     end
 
     it("does nothing when enable is false", function()
       mock_install(true)
-      lsp.setup({ enable = false, cmd = { "surreal-language-server" } })
+      lsp.setup({ enable = false, cmd = { "surrealql-language-server" } })
       local ok, _ = pcall(vim.api.nvim_get_autocmds, { group = "surrealql_lsp" })
       assert.is_false(ok)
     end)
 
     it("creates a FileType autocmd when binary is installed", function()
       mock_install(true)
-      lsp.setup({ enable = true, cmd = { "surreal-language-server" } })
+      lsp.setup({ enable = true, cmd = { "surrealql-language-server" } })
       local autocmds = vim.api.nvim_get_autocmds({ group = "surrealql_lsp", event = "FileType" })
       assert.equals(1, #autocmds)
       assert.equals("surrealql", autocmds[1].pattern)
@@ -38,8 +38,8 @@ describe("surrealql.lsp", function()
 
     it("replaces a previous autocmd group on repeated setup calls", function()
       mock_install(true)
-      lsp.setup({ enable = true, cmd = { "surreal-language-server" } })
-      lsp.setup({ enable = true, cmd = { "surreal-language-server" } })
+      lsp.setup({ enable = true, cmd = { "surrealql-language-server" } })
+      lsp.setup({ enable = true, cmd = { "surrealql-language-server" } })
       local autocmds = vim.api.nvim_get_autocmds({ group = "surrealql_lsp", event = "FileType" })
       assert.equals(1, #autocmds)
     end)
@@ -51,7 +51,7 @@ describe("surrealql.lsp", function()
         install = function(cb) installed_cb = cb end,
       }
 
-      lsp.setup({ enable = true, auto_install = true, cmd = { "surreal-language-server" } })
+      lsp.setup({ enable = true, auto_install = true, cmd = { "surrealql-language-server" } })
       assert.is_nil(vim.api.nvim_get_autocmds and (function()
         local ok, cmds = pcall(vim.api.nvim_get_autocmds, { group = "surrealql_lsp" })
         return ok and cmds[1] or nil
@@ -71,7 +71,7 @@ describe("surrealql.lsp", function()
       vim.notify = function(_, level)
         if level == vim.log.levels.WARN then warned = true end
       end
-      lsp.setup({ enable = true, auto_install = false, cmd = { "surreal-language-server" } })
+      lsp.setup({ enable = true, auto_install = false, cmd = { "surrealql-language-server" } })
       vim.notify = orig
       assert.is_true(warned)
     end)
@@ -83,12 +83,12 @@ describe("surrealql.lsp", function()
       local orig = vim.lsp.start
       vim.lsp.start = function(cfg) captured = cfg end
 
-      lsp.start({ cmd = { "surreal-language-server" } })
+      lsp.start({ cmd = { "surrealql-language-server" } })
 
       vim.lsp.start = orig
       assert.is_not_nil(captured)
       assert.equals("surrealql", captured.name)
-      assert.same({ "surreal-language-server" }, captured.cmd)
+      assert.same({ "surrealql-language-server" }, captured.cmd)
     end)
 
     it("passes on_attach and capabilities through", function()
@@ -98,7 +98,7 @@ describe("surrealql.lsp", function()
 
       local on_attach = function() end
       local caps = { textDocument = {} }
-      lsp.start({ cmd = { "surreal-language-server" }, on_attach = on_attach, capabilities = caps })
+      lsp.start({ cmd = { "surrealql-language-server" }, on_attach = on_attach, capabilities = caps })
 
       vim.lsp.start = orig
       assert.equals(on_attach, captured.on_attach)
@@ -110,7 +110,7 @@ describe("surrealql.lsp", function()
       local orig = vim.lsp.start
       vim.lsp.start = function(cfg) captured = cfg end
 
-      lsp.start({ cmd = { "surreal-language-server" } })
+      lsp.start({ cmd = { "surrealql-language-server" } })
 
       vim.lsp.start = orig
       assert.truthy(vim.tbl_contains(captured.filetypes, "surrealql"))
@@ -122,8 +122,8 @@ describe("surrealql.lsp", function()
       assert.is_false(defaults.enable)
     end)
 
-    it("default cmd is surreal-language-server", function()
-      assert.same({ "surreal-language-server" }, defaults.cmd)
+    it("default cmd is surrealql-language-server", function()
+      assert.same({ "surrealql-language-server" }, defaults.cmd)
     end)
   end)
 end)

--- a/tests/surrealql_spec.lua
+++ b/tests/surrealql_spec.lua
@@ -61,7 +61,9 @@ describe("surrealql", function()
       assert.equals(defaults.treesitter.branch, parser_configs.surrealql.install_info.branch)
     end)
 
-    it("does not overwrite an existing registration", function()
+    it("updates install_info on an existing registration", function()
+      -- A later call (e.g. from setup() with user opts) must override the
+      -- eager default registration, not be ignored.
       local original = { filetype = "surrealql", install_info = { url = "original" } }
       local parser_configs = { surrealql = original }
       package.loaded["nvim-treesitter.parsers"] = {
@@ -70,7 +72,9 @@ describe("surrealql", function()
 
       surrealql._register_parser(defaults.treesitter)
 
-      assert.equals("original", parser_configs.surrealql.install_info.url)
+      assert.equals(defaults.treesitter.url, parser_configs.surrealql.install_info.url)
+      assert.equals(defaults.treesitter.branch, parser_configs.surrealql.install_info.branch)
+      assert.equals("surrealql", parser_configs.surrealql.filetype)
     end)
   end)
 end)


### PR DESCRIPTION
Fixes several issues in the LSP integration and the Treesitter parser setup, found while testing the plugin end-to-end.

## 1. Language-server binary name (critical)

The binary is **`surrealql-language-server`**, but several spots used `surreal-language-server` (missing "ql"), which stops the LSP from starting on the paths that don't go through the managed download:
- `config.lua` default `cmd`
- `install.lua` — PATH-detection fallback (a manually-installed binary on `PATH` wasn't detected) and the cargo-build fallback's returned command
- `lsp.lua` warning text
- README + tests

## 2. cargo fallback actually works now

On platforms without a prebuilt binary (e.g. macOS Intel) the plugin ran `cargo install surrealql-language-server`, which **panics in `build.rs`**: the published crate builds against the sibling `surrealql-tree-sitter` grammar and isn't bundled with it. The fallback now fetches the grammar into the plugin data dir and runs the build with `TREE_SITTER_SURREALQL_DIR` pointed at it (needs `git` + `cargo`).

## 3. Version-gap guard

Auto-install uses `vim.system` (Neovim 0.10+) and `vim.uv`. Now uses `vim.uv or vim.loop`, notifies instead of throwing when `vim.system` is unavailable, and docs state LSP auto-install needs 0.10 (Treesitter still works on supported Neovim — see ABI note below).

## 4. `lsp.start` crash on project-less files

`vim.fs.dirname(vim.fs.find({...})[1])` was called with `nil` when no `.git`/`surreal.json` marker existed, crashing on a standalone `.surql` file. Now guarded with a `getcwd()` fallback.

## 5. Grammar branch default (404)

`treesitter.branch` defaulted to `"main"`, but the grammar repo has **no `main` branch** (default is `master`) — so nvim-treesitter fetched a 404 archive. Default to `master`.

## 6. `setup()` couldn't override parser registration

The plugin eager-registers the parser at load with defaults, and `_register_parser` bailed if an entry already existed — so a later `setup({ treesitter = { branch = ... } })` was silently ignored. It now **updates `install_info` on an existing entry**, so the post-`setup()` config wins regardless of load order.

## 7. Docs refresh

- Server capability list updated: **semantic-token highlighting**, inlay hints, document/workspace symbols, document highlight — with a note that semantic tokens **refine** (not replace) the Treesitter highlighting.
- **Tree-sitter ABI note:** the `master` grammar is ABI 15, which needs **Neovim 0.12+**; on 0.11 the parser is rejected. This affects only the Treesitter path — the **LSP's semantic-token highlighting is unaffected** (the server bundles its own tree-sitter runtime), so it works on 0.10/0.11. ABI-14 support for 0.11 is tracked separately in the grammar repo.

## Not included (follow-ups)

- The nvim-treesitter `master`/`main` API split (`get_parser_configs`) — the self-contained registration refactor (`vim.treesitter.language.add` + `vim.treesitter.start`) is a separate change.
- The ABI-15 → ABI-14 decision itself lives in `surrealql-tree-sitter`.

## Testing

`make test` — all specs pass (26 tests, 0 failures). Fixtures updated for the corrected binary name, branch default, and the update-on-existing registration behavior.