### PR TITLE
Install/registration robustness: cargo fallback, root_dir guard, setup() override

### DIFF
--- a/lua/surrealql/init.lua
+++ b/lua/surrealql/init.lua
@@ -37,21 +37,22 @@ function M._register_parser(ts_config)
   end
 
   local parser_configs = parsers.get_parser_configs()
-  if parser_configs.surrealql then
-    return
-  end
 
-  parser_configs.surrealql = {
-    install_info = {
-      url = ts_config.url,
-      files = ts_config.files,
-      branch = ts_config.branch,
-      generate_requires_npm = false,
-      requires_generate_from_grammar = false,
-    },
-    filetype = "surrealql",
-    maintainers = { "@surrealdb" },
+  -- Update `install_info` on an existing entry rather than bailing out.
+  -- The plugin eager-registers at load with defaults (before `setup()`),
+  -- so returning early when an entry already existed made
+  -- `setup({ treesitter = ... })` a silent no-op. Every caller passes the
+  -- live config, so the post-`setup()` merged config correctly wins.
+  local entry = parser_configs.surrealql
+    or { filetype = "surrealql", maintainers = { "@surrealdb" } }
+  entry.install_info = {
+    url = ts_config.url,
+    files = ts_config.files,
+    branch = ts_config.branch,
+    generate_requires_npm = false,
+    requires_generate_from_grammar = false,
   }
+  parser_configs.surrealql = entry
 end
 
 return M

--- a/lua/surrealql/install.lua
+++ b/lua/surrealql/install.lua
@@ -1,6 +1,9 @@
 local M = {}
 
+local uv = vim.uv or vim.loop
+
 local REPO = "surrealdb/surrealql-language-server"
+local GRAMMAR_REPO = "https://github.com/surrealdb/surrealql-tree-sitter"
 
 local PLATFORM_BINARIES = {
   ["linux-x86_64"]  = "surrealql-language-server-linux-amd64",
@@ -10,7 +13,7 @@ local PLATFORM_BINARIES = {
 }
 
 local function platform_key()
-  local uname = vim.uv.os_uname()
+  local uname = uv.os_uname()
   local sys = uname.sysname:lower()
   local arch = uname.machine:lower()
 
@@ -27,7 +30,7 @@ end
 
 function M.bin_path()
   local name = "surrealql-language-server"
-  if vim.uv.os_uname().sysname:lower():find("windows") then
+  if uv.os_uname().sysname:lower():find("windows") then
     name = name .. ".exe"
   end
   return vim.fn.stdpath("data") .. "/surrealql/bin/" .. name
@@ -59,10 +62,42 @@ local function download(filename, on_done)
       end)
       return
     end
-    vim.uv.fs_chmod(dest, 493) -- 0755
+    uv.fs_chmod(dest, 493) -- 0755
     vim.schedule(function()
       vim.notify("[surrealql] Language server installed.", vim.log.levels.INFO)
       on_done(true, dest)
+    end)
+  end)
+end
+
+-- The published crate's build.rs compiles against the sibling tree-sitter
+-- grammar repo (`../surrealql-tree-sitter` or `TREE_SITTER_SURREALQL_DIR`)
+-- and is not bundled with it, so a bare `cargo install` panics. Fetch the
+-- grammar into the plugin's data dir and point the build at it.
+local function ensure_grammar(on_done)
+  local dir = vim.fn.stdpath("data") .. "/surrealql/surrealql-tree-sitter"
+  if vim.fn.isdirectory(dir) == 1 then
+    on_done(true, dir)
+    return
+  end
+  if vim.fn.executable("git") == 0 then
+    vim.notify(
+      "[surrealql] git not found; cannot fetch the tree-sitter grammar needed to build from source.",
+      vim.log.levels.ERROR
+    )
+    on_done(false)
+    return
+  end
+  vim.fn.mkdir(vim.fn.fnamemodify(dir, ":h"), "p")
+  vim.notify("[surrealql] Fetching tree-sitter grammar for build...", vim.log.levels.INFO)
+  vim.system({ "git", "clone", "--depth", "1", GRAMMAR_REPO, dir }, {}, function(result)
+    vim.schedule(function()
+      if result.code ~= 0 then
+        vim.notify("[surrealql] Grammar clone failed: " .. (result.stderr or ""), vim.log.levels.ERROR)
+        on_done(false)
+        return
+      end
+      on_done(true, dir)
     end)
   end)
 end
@@ -77,21 +112,45 @@ local function cargo_install(on_done)
     return
   end
 
-  vim.notify("[surrealql] Building language server via cargo (this may take a while)...", vim.log.levels.INFO)
-
-  vim.system({ "cargo", "install", "surrealql-language-server" }, {}, function(result)
-    if result.code ~= 0 then
-      vim.schedule(function()
-        vim.notify("[surrealql] cargo install failed: " .. (result.stderr or ""), vim.log.levels.ERROR)
-        on_done(false)
-      end)
+  ensure_grammar(function(ok, grammar_dir)
+    if not ok then
+      on_done(false)
       return
     end
-    vim.schedule(function()
-      vim.notify("[surrealql] Language server installed via cargo.", vim.log.levels.INFO)
-      on_done(true, "surrealql-language-server")
-    end)
+    vim.notify("[surrealql] Building language server via cargo (this may take a while)...", vim.log.levels.INFO)
+    vim.system(
+      { "cargo", "install", "surrealql-language-server" },
+      { env = { TREE_SITTER_SURREALQL_DIR = grammar_dir } },
+      function(result)
+        if result.code ~= 0 then
+          vim.schedule(function()
+            vim.notify("[surrealql] cargo install failed: " .. (result.stderr or ""), vim.log.levels.ERROR)
+            on_done(false)
+          end)
+          return
+        end
+        vim.schedule(function()
+          vim.notify("[surrealql] Language server installed via cargo.", vim.log.levels.INFO)
+          -- Installed onto ~/.cargo/bin, expected to be on PATH.
+          on_done(true, "surrealql-language-server")
+        end)
+      end
+    )
   end)
+end
+
+-- Auto-install relies on `vim.system` (Neovim 0.10+). Fail loudly on older
+-- versions rather than throwing a nil-call error mid-install.
+local function ensure_system()
+  if vim.system then
+    return true
+  end
+  vim.notify(
+    "[surrealql] Automatic install requires Neovim 0.10+. Install surrealql-language-server "
+      .. "manually and point lsp.cmd at it (auto_install = false).",
+    vim.log.levels.ERROR
+  )
+  return false
 end
 
 function M.install(on_done)
@@ -101,6 +160,11 @@ function M.install(on_done)
   if ok then
     vim.notify("[surrealql] Language server is already installed.", vim.log.levels.INFO)
     on_done(true)
+    return
+  end
+
+  if not ensure_system() then
+    on_done(false)
     return
   end
 

--- a/lua/surrealql/lsp.lua
+++ b/lua/surrealql/lsp.lua
@@ -1,9 +1,10 @@
 local M = {}
 
 function M.start(lsp_config)
-  local root = vim.fs.dirname(
-    vim.fs.find({ ".git", "surreal.json" }, { upward = true })[1]
-  ) or vim.fn.getcwd()
+  -- `vim.fs.dirname(nil)` errors, so guard the no-marker case (a `.surql`
+  -- file opened outside any project) instead of crashing on attach.
+  local marker = vim.fs.find({ ".git", "surreal.json" }, { upward = true })[1]
+  local root = (marker and vim.fs.dirname(marker)) or vim.fn.getcwd()
 
   vim.lsp.start({
     name = "surrealql",

--- a/tests/surrealql_spec.lua
+++ b/tests/surrealql_spec.lua
@@ -69,7 +69,9 @@ describe("surrealql", function()
       assert.equals(defaults.treesitter.branch, parser_configs.surrealql.install_info.branch)
     end)
 
-    it("does not overwrite an existing registration", function()
+    it("updates install_info on an existing registration", function()
+      -- A later call (e.g. setup() with user opts, after the eager default
+      -- registration at plugin load) must override, not be ignored.
       local original = { filetype = "surrealql", install_info = { url = "original" } }
       local parser_configs = { surrealql = original }
       package.loaded["nvim-treesitter.parsers"] = {
@@ -78,7 +80,9 @@ describe("surrealql", function()
 
       surrealql._register_parser(defaults.treesitter)
 
-      assert.equals("original", parser_configs.surrealql.install_info.url)
+      assert.equals(defaults.treesitter.url, parser_configs.surrealql.install_info.url)
+      assert.equals(defaults.treesitter.branch, parser_configs.surrealql.install_info.branch)
+      assert.equals("surrealql", parser_configs.surrealql.filetype)
     end)
   end)
 end)


### PR DESCRIPTION
Small robustness fixes branched from current `main` (no overlap with the already-merged #4/#5/#6).

### 1. cargo fallback actually builds
On platforms with no prebuilt binary (e.g. macOS Intel), `install.lua` falls back to `cargo install surrealql-language-server`. That **panics in the crate's `build.rs`**: the published crate compiles against the sibling `surrealql-tree-sitter` grammar repo and isn't bundled with it. This fetches the grammar into the plugin data dir and runs the build with `TREE_SITTER_SURREALQL_DIR` pointed at it (needs `git` + `cargo`).

### 2. Version guard for auto-install
Auto-install uses `vim.system` (Neovim 0.10+) and `vim.uv`. Now uses `vim.uv or vim.loop` and notifies clearly instead of throwing a nil-call error on older Neovim.

### 3. `lsp.start` no longer crashes outside a project
`vim.fs.dirname(nil)` errored when no `.git`/`surreal.json` marker was found (a `.surql` file opened standalone). Guarded with a `getcwd()` fallback.

### 4. `setup()` can override the parser registration
`_register_parser` bailed out when an entry already existed, so the eager default registration at plugin load made `setup({ treesitter = ... })` a silent no-op. It now updates `install_info` on an existing entry (keeping the nvim-treesitter `main` nil-guard from #6), so the post-`setup()` config wins.

### Notes
- Replaces my earlier #7, which was based on a stale checkout and duplicated the merged #4/#6.
- `make test` passes (28 tests; the registration test was flipped to assert the override behavior).