### PR TITLE
fix: highlight surql`` template literals (add injection.include-children)

### DIFF
--- a/after/queries/javascript/injections.scm
+++ b/after/queries/javascript/injections.scm
@@ -2,12 +2,16 @@
 
 ; Highlight SurrealQL inside surql`...` / surrealql`...` tagged template
 ; literals (e.g. the surrealdb JavaScript/TypeScript SDK). #offset! trims the
-; surrounding backticks from the injected region.
+; surrounding backticks from the injected region. injection.include-children is
+; required because a template_string wraps its text in a (string_fragment)
+; child; without it the host masks that child out and the injected range is
+; empty, so no highlighting is applied.
 ((call_expression
    function: (identifier) @_tag
    arguments: (template_string) @injection.content)
  (#any-of? @_tag "surql" "surrealql")
  (#set! injection.language "surrealql")
+ (#set! injection.include-children)
  (#offset! @injection.content 0 1 0 -1))
 
 ; member-expression tag, e.g. db.surql`...`
@@ -17,4 +21,5 @@
    arguments: (template_string) @injection.content)
  (#any-of? @_tag "surql" "surrealql")
  (#set! injection.language "surrealql")
+ (#set! injection.include-children)
  (#offset! @injection.content 0 1 0 -1))

--- a/after/queries/tsx/injections.scm
+++ b/after/queries/tsx/injections.scm
@@ -2,12 +2,16 @@
 
 ; Highlight SurrealQL inside surql`...` / surrealql`...` tagged template
 ; literals (e.g. the surrealdb JavaScript/TypeScript SDK). #offset! trims the
-; surrounding backticks from the injected region.
+; surrounding backticks from the injected region. injection.include-children is
+; required because a template_string wraps its text in a (string_fragment)
+; child; without it the host masks that child out and the injected range is
+; empty, so no highlighting is applied.
 ((call_expression
    function: (identifier) @_tag
    arguments: (template_string) @injection.content)
  (#any-of? @_tag "surql" "surrealql")
  (#set! injection.language "surrealql")
+ (#set! injection.include-children)
  (#offset! @injection.content 0 1 0 -1))
 
 ; member-expression tag, e.g. db.surql`...`
@@ -17,4 +21,5 @@
    arguments: (template_string) @injection.content)
  (#any-of? @_tag "surql" "surrealql")
  (#set! injection.language "surrealql")
+ (#set! injection.include-children)
  (#offset! @injection.content 0 1 0 -1))

--- a/after/queries/typescript/injections.scm
+++ b/after/queries/typescript/injections.scm
@@ -2,12 +2,16 @@
 
 ; Highlight SurrealQL inside surql`...` / surrealql`...` tagged template
 ; literals (e.g. the surrealdb JavaScript/TypeScript SDK). #offset! trims the
-; surrounding backticks from the injected region.
+; surrounding backticks from the injected region. injection.include-children is
+; required because a template_string wraps its text in a (string_fragment)
+; child; without it the host masks that child out and the injected range is
+; empty, so no highlighting is applied.
 ((call_expression
    function: (identifier) @_tag
    arguments: (template_string) @injection.content)
  (#any-of? @_tag "surql" "surrealql")
  (#set! injection.language "surrealql")
+ (#set! injection.include-children)
  (#offset! @injection.content 0 1 0 -1))
 
 ; member-expression tag, e.g. db.surql`...`
@@ -17,4 +21,5 @@
    arguments: (template_string) @injection.content)
  (#any-of? @_tag "surql" "surrealql")
  (#set! injection.language "surrealql")
+ (#set! injection.include-children)
  (#offset! @injection.content 0 1 0 -1))


### PR DESCRIPTION
## Problem

The JS/TS `` surql`...` `` / `` surrealql`...` `` template-literal injection (shipped in #5) never highlighted anything. The feature looked correct on every individual signal — the query parses, `iter_matches` yields the match with `injection.language = surrealql`, the `surrealql` parser loads and `resolve_lang` succeeds — yet no injected child tree was ever created, so the failure was completely silent.

## Root cause

A `template_string` node wraps its text in a `(string_fragment)` named child. When `injection.include-children` is **not** set, Neovim core's `get_node_ranges` (`runtime/lua/vim/treesitter/languagetree.lua`) masks out the named children's ranges. With the whole content living in that single `string_fragment` child, the masked result is an empty range, and `add_injection` then drops the injection via its `#ranges == 0` guard.

## Fix

Add `(#set! injection.include-children)` to both patterns (identifier tag and member-expression tag) in all three `after/queries/{javascript,typescript,tsx}/injections.scm`.

## Verification

Tested end-to-end in an isolated Neovim (nvim-treesitter `main`, real `javascript`/`typescript`/`tsx`/`surrealql` parsers compiled and installed). Before the change, parsing produced no `surrealql` child tree and `SELECT` inside the literal resolved only to `typescript@string`. After the change, all of the following resolve to `surrealql@*` captures, while an untagged backtick correctly stays un-injected (5/5):

| filetype | tag form | result |
|---|---|---|
| typescript | `` surql`...` `` | `surrealql@keyword` ✅ |
| typescript | `` db.surql`...` `` | `surrealql@keyword` ✅ |
| typescriptreact (tsx) | `` surrealql`...` `` | `surrealql@keyword` ✅ |
| javascript | `` db.surrealql`...` `` | `surrealql@keyword` ✅ |
| javascript | untagged `` `...` `` (control) | no injection ✅ |

## Note

The existing `tests/injection_spec.lua` only asserts the query *parses*, not that it actually injects — which is why this shipped broken. A true end-to-end regression test needs real parsers installed (the current CI installs none), so it would require a gated job; happy to follow up on that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)